### PR TITLE
Remove unused prettier task from taskfile

### DIFF
--- a/taskfile.yml
+++ b/taskfile.yml
@@ -57,11 +57,6 @@ tasks:
     cmds:
       - markdownlint --fix "{{.MD_FILES}}"
 
-  pretty:
-    desc: Format files using prettier
-    cmds:
-      - npx prettier --write "{{.MD_FILES}}"
-
   clean:
     desc: Clean build artifacts
     cmds:


### PR DESCRIPTION
The prettier task was referencing Node.js tooling (npx) in a Go project without any supporting configuration (package.json, .prettierrc). Since markdownlint already handles Markdown formatting, prettier is unnecessary overhead.