### PR TITLE
Update benchmark tests to use b.Loop() API

### DIFF
--- a/dice/dice_bench_test.go
+++ b/dice/dice_bench_test.go
@@ -7,37 +7,37 @@ import (
 )
 
 func BenchmarkD(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dice.D(20)
 	}
 }
 
 func BenchmarkD6(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dice.D6()
 	}
 }
 
 func BenchmarkD20(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dice.D20()
 	}
 }
 
 func BenchmarkRoll(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dice.Roll(3, 6)
 	}
 }
 
 func BenchmarkRoll2D6(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dice.Roll2D6()
 	}
 }
 
 func BenchmarkRoll3D6(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dice.Roll3D6()
 	}
 }


### PR DESCRIPTION
Replace deprecated for loop with b.N iterations with Go 1.25's new b.Loop() API for more idiomatic benchmark iteration.