### PR TITLE
Add repository settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,53 +1,8 @@
+_extends: .github
+
 repository:
   name: go
-  description: go tool and libraries
-  homepage: https://philoserf.github.io/go
-  topics: go
-  private: false
-  has_issues: true
-  has_projects: false
-  has_wiki: false
-  has_downloads: false
-  default_branch: main
-  allow_squash_merge: true
-  allow_merge_commit: false
-  allow_rebase_merge: false
-  enable_automated_security_fixes: true
-  enable_vulnerability_alerts: true
-
-labels:
-  - name: bug
-    description: An unexpected problem or unintended behavior
-  - name: documentation
-    description: A need for improvements or additions to documentation
-  - name: duplicate
-    description: Similar to another issues or pull requests
-  - name: enhancement
-    description: New feature requests
-  - name: invalid
-    description: An issue or pull request is no longer relevant
-  - name: question
-    description: An issue or pull request needs more information
-  - name: wontfix
-    description: Work won't continue on an issue or pull request
-  - name: chore
-    description: Work unrelated to the core purpose
-
-branches:
-  - name: main
-    protection:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
-        dismissal_restrictions:
-          users:
-            - philoserf
-      required_status_checks:
-        strict: true
-        contexts: []
-      enforce_admins: null
-      restrictions:
-        apps: []
-        users: []
-        teams: []
+  description: "tools and libraries"
+  homepage: https://philoserf.github.io/go/
+  topics:
+    - go


### PR DESCRIPTION
Add `.github/settings.yml` for declarative repo settings via [probot/settings](https://github.com/repository-settings/app).

This config extends the base settings from `philoserf/.github` and includes repo-specific metadata and overrides.

Settings are applied automatically when the Settings app is installed and this PR is merged.